### PR TITLE
fix: double close in resultset.Reader

### DIFF
--- a/pkg/resultset/resultset.go
+++ b/pkg/resultset/resultset.go
@@ -46,7 +46,6 @@ func (s ResultSet) Swap(i, j int) {
 // NewReader returns a new ResultSetReader with bucket.
 func (s ResultSet) NewReader(ctx context.Context, bucket obj.Bucket) *Reader {
 	return &Reader{
-		ctx:    ctx,
 		bucket: bucket,
 		set:    s,
 	}


### PR DESCRIPTION
Fix double close in resultset.Reader.
This also removes context.Context from the struct because
it is not recommended and breaks cancellations.