### PR TITLE
Change maxDigitsPerRequest to higher value.

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -35,7 +35,7 @@ import (
 var _serv *service.Service
 var _servOnce sync.Once
 
-var maxDigitsPerRequest = 1000
+var maxDigitsPerRequest = 100000
 var bucketName = index.BucketName
 
 const (


### PR DESCRIPTION
Searching for values inside PI sequence would be very faster after changing this limit.